### PR TITLE
Add CI to build and test experimental behaviors

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,79 @@
+---
+BasedOnStyle:  Google
+ColumnLimit:    120
+MaxEmptyLinesToKeep: 1
+
+# Allow us to adhere to https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes
+IncludeBlocks: Preserve
+SortIncludes: true
+
+Standard:        Auto
+IndentWidth:     2
+TabWidth:        2
+UseTab:          Never
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+NamespaceIndentation: None
+ContinuationIndentWidth: 4
+IndentCaseLabels: true
+IndentFunctionDeclarationAfterType: false
+
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+ExperimentalAutoDetectBinPacking: false
+ObjCSpaceBeforeProtocolList: true
+Cpp11BracedListStyle: false
+
+AllowShortBlocksOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortCaseLabelsOnASingleLine: false
+
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+
+BinPackParameters: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: false
+PointerBindsToType: true
+
+PenaltyExcessCharacter: 50
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 1000
+PenaltyBreakFirstLessLess: 10
+PenaltyBreakString: 100
+PenaltyReturnTypeOnItsOwnLine: 50
+
+SpacesBeforeTrailingComments: 2
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping:
+    AfterCaseLabel: true
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+IncludeBlocks: Preserve
+...

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Add Git LFS support for common 3D file formats
+*.onnx filter=lfs diff=lfs merge=lfs -text
+*.stl filter=lfs diff=lfs merge=lfs -text
+*.STL filter=lfs diff=lfs merge=lfs -text
+*.obj filter=lfs diff=lfs merge=lfs -text
+*.fbx filter=lfs diff=lfs merge=lfs -text
+*.dae filter=lfs diff=lfs merge=lfs -text
+*.gltf filter=lfs diff=lfs merge=lfs -text
+*.glb filter=lfs diff=lfs merge=lfs -text
+*.ply filter=lfs diff=lfs merge=lfs -text
+*.3ds filter=lfs diff=lfs merge=lfs -text
+*.blend filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+install/
+log/
+.ccache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,85 @@
+# To use:
+#
+#     pre-commit run -a
+#
+# Or:
+#
+#     pre-commit install  # (runs every time you commit in git)
+#
+# To update this file:
+#
+#     pre-commit autoupdate
+#
+# See https://github.com/pre-commit/pre-commit
+repos:
+  # Standard hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+        args: ["--unsafe"] # Fixes errors parsing custom YAML constructors like ur_description's !degrees
+      - id: debug-statements
+      - id: end-of-file-fixer
+        exclude: (\.(svg|stl|dae))$
+      - id: mixed-line-ending
+      - id: fix-byte-order-marker
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.0.0
+    hooks:
+      - id: codespell
+        args: ["--write-changes", "-L", "atleast,inout,ether"] # Provide a comma-separated list of misspelled words that codespell should ignore (for example: '-L', 'word1,word2,word3').
+        exclude: \.(svg|pyc|stl|dae|lock)$
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v14.0.6
+    hooks:
+      - id: clang-format
+        files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|proto|vert)$
+        # -i arg is included by default by the hook
+        args: ["-fallback-style=none"]
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.27.1
+    hooks:
+      - id: yamllint
+        args:
+          [
+            "--no-warnings",
+            "--config-data",
+            "{extends: default, rules: {line-length: disable, braces: {max-spaces-inside: 1}, indentation: {spaces: consistent, indent-sequences: whatever}}}",
+          ]
+        types: [text]
+        files: \.(yml|yaml)$
+
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.10.3
+    hooks:
+      - id: markdown-link-check
+
+  # NOTE: Broken on arm64. Will need to bump once https://github.com/hadolint/hadolint/issues/840 is fixed.
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.10.0
+    hooks:
+      - id: hadolint-docker
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.1.0"
+    hooks:
+      # Use Prettier to lint XML files because, well.. its rules are prettier than most linters, as the name implies.
+      # Also we use it in the UI, so it's familiar.
+      - id: prettier
+        additional_dependencies:
+          - "prettier@3.1.0"
+          - "@prettier/plugin-xml@3.3.1"
+        files: \.(xml)$

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [require.resolve("@prettier/plugin-xml")],
+  xmlWhitespaceSensitivity: "ignore",
+  xmlQuoteAttributes: "double"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+Any contribution that you make to this repository will
+be under the 3-Clause BSD License, as dictated by that
+[license](https://opensource.org/licenses/BSD-3-Clause).
+
+# Contributing to this Repository
+
+Thanks for getting involved! If you want to add to this repository, please reach out to support@picknik.ai.

--- a/colcon-defaults.yaml
+++ b/colcon-defaults.yaml
@@ -1,0 +1,19 @@
+# Contains colcon default settings for user overlay containers.
+build:
+  # Enable this for bidirectional syncing from the UI
+  symlink-install: true
+  mixin:
+    # Enable ccache support
+    - ccache
+    # Multithreaded linker to speed up linking step during compilation
+    - lld
+    - compile-commands
+    # Debug info and build testing for dev workflows
+    - rel-with-deb-info
+    - build-testing-on
+    - coverage-gcc
+    - coverage-pytest
+test:
+  event-handlers:
+    - console_direct+
+    - desktop_notification+

--- a/workflows/CI.yaml
+++ b/workflows/CI.yaml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'The tag of the image to use for the container'
+        required: false
+        default: ''
+
+jobs:
+  integration-test-in-studio-container:
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@virtual-buffer
+    with:
+      image_tag: ${{ github.event.inputs.image_tag || null }}
+      colcon_test_args: "--executor sequential"
+    secrets: inherit
+
+  ensure-no-ssh-in-gitmodules:
+    name: Ensure no SSH URLs in .gitmodules
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check .gitmodules file for Git-over-SSH URLs
+        run: "! grep 'git@' .gitmodules"

--- a/workflows/format.yaml
+++ b/workflows/format.yaml
@@ -1,0 +1,17 @@
+name: Format
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Based on https://github.com/PickNikRobotics/moveit_pro_experimental_behaviors/pull/1

Just copies and pastes the [moveit_pro_example_ws CI](https://github.com/PickNikRobotics/moveit_pro_example_ws/blame/main/.github/workflows/ci.yaml). The only changes I made was:

- Remove the objective validator
- Removed scheduled runs (I figured that we don't need to spend the CI time for this if it is included as a submodule in the example ws) and added explicit activity types for triggering runs on pull requests.

I believe this repository needs it's settings altered to require these checks after this PR is merged to start triggering Ci.