### PR TITLE
feat(behaviors): add pose conversion, basis change, snapshot subscribers, Bool/Empty publishers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(experimental_behaviors CXX)
 find_package(moveit_studio_common REQUIRED)
 moveit_studio_package()
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS control_msgs geometry_msgs moveit_pro_behavior_interface pluginlib moveit_studio_common behaviortree_cpp tl_expected trajectory_msgs moveit_pro_base)
+set(THIS_PACKAGE_INCLUDE_DEPENDS control_msgs geometry_msgs moveit_pro_behavior_interface pluginlib moveit_studio_common behaviortree_cpp nav_msgs std_msgs tl_expected trajectory_msgs moveit_pro_base)
 foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${package} REQUIRED)
 endforeach()
@@ -22,6 +22,16 @@ add_library(
   src/get_blackboard_by_key.cpp
   src/set_blackboard_by_key.cpp
   src/trajectory_to_path.cpp
+  src/pose_to_vectors.cpp
+  src/vectors_to_pose.cpp
+  src/convert_odom_to_pose_stamped.cpp
+  src/convert_pose_stamped_to_odom.cpp
+  src/get_odom_latest.cpp
+  src/publish_bool.cpp
+  src/get_bool.cpp
+  src/get_bool_instance.cpp
+  src/get_empty_instance.cpp
+  src/get_odom_instance.cpp
   src/register_behaviors.cpp)
 target_include_directories(
   experimental_behaviors

--- a/include/experimental_behaviors/convert_odom_to_pose_stamped.hpp
+++ b/include/experimental_behaviors/convert_odom_to_pose_stamped.hpp
@@ -1,0 +1,39 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <behaviortree_cpp/action_node.h>
+
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Converts a `nav_msgs/Odometry` message into a `geometry_msgs/PoseStamped`,
+ *        preserving header and pose; the twist field is dropped.
+ *
+ * | Data Port Name | Port Type | Object Type                     |
+ * | -------------- | --------- | ------------------------------- |
+ * | odometry       | input     | nav_msgs::msg::Odometry         |
+ * | pose_stamped   | output    | geometry_msgs::msg::PoseStamped |
+ */
+class ConvertOdomToPoseStamped final : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  ConvertOdomToPoseStamped(const std::string& name, const BT::NodeConfiguration& config,
+                           const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/convert_pose_stamped_to_odom.hpp
+++ b/include/experimental_behaviors/convert_pose_stamped_to_odom.hpp
@@ -1,0 +1,40 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <behaviortree_cpp/action_node.h>
+
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Converts a `geometry_msgs/PoseStamped` into a `nav_msgs/Odometry`,
+ *        preserving header and pose; twist is left zero-initialized.
+ *
+ * | Data Port Name | Port Type | Object Type                     |
+ * | -------------- | --------- | ------------------------------- |
+ * | pose_stamped   | input     | geometry_msgs::msg::PoseStamped |
+ * | child_frame    | input     | std::string (optional)          |
+ * | odom           | output    | nav_msgs::msg::Odometry         |
+ */
+class ConvertPoseStampedToOdom final : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  ConvertPoseStampedToOdom(const std::string& name, const BT::NodeConfiguration& config,
+                           const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/get_bool.hpp
+++ b/include/experimental_behaviors/get_bool.hpp
@@ -1,0 +1,54 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <optional>
+#include <shared_mutex>
+
+#include <behaviortree_cpp/action_node.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
+
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Long-lived `std_msgs/Bool` subscriber that writes the latest received value to the
+ *        blackboard every tick. Returns RUNNING forever; halted by the parent on parallel
+ *        completion.
+ *
+ * @details Uses `std::optional<bool>` for the cached value and skips `setOutput` until the
+ *          first real message arrives. Without this, a default-constructed `false` would be
+ *          written on the first onRunning tick, clobbering any pre-seeded blackboard value
+ *          before the publisher has delivered a real sample.
+ *
+ * | Data Port Name   | Port Type | Object Type |
+ * | ---------------- | --------- | ----------- |
+ * | bool_topic_name  | input     | std::string |
+ * | subscribed_bool  | output    | bool        |
+ */
+class GetBool : public moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>
+{
+public:
+  GetBool(const std::string& name, const BT::NodeConfiguration& config,
+          const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+private:
+  BT::NodeStatus onStart() override;
+  BT::NodeStatus onRunning() override;
+  void onHalted() override;
+
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr bool_subscriber_;
+  std::shared_mutex bool_mutex_;
+  std::optional<bool> current_bool_value_;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/get_bool_instance.hpp
+++ b/include/experimental_behaviors/get_bool_instance.hpp
@@ -1,0 +1,52 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <optional>
+#include <shared_mutex>
+#include <string>
+
+#include <behaviortree_cpp/action_node.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
+
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Snapshot-style `std_msgs/Bool` subscriber. Blocks until the first message arrives,
+ *        then returns SUCCESS and tears down its subscription. Outputs the full Bool
+ *        message (not the primitive bool) — useful when downstream consumers need the
+ *        ROS message wrapper. For streaming the primitive value, use `GetBool` instead.
+ *
+ * | Data Port Name           | Port Type | Object Type         |
+ * | ------------------------ | --------- | ------------------- |
+ * | bool_topic_name          | input     | std::string         |
+ * | subscribed_bool_instance | output    | std_msgs::msg::Bool |
+ */
+class GetBoolInstance : public moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>
+{
+public:
+  GetBoolInstance(const std::string& name, const BT::NodeConfiguration& config,
+                  const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+private:
+  BT::NodeStatus onStart() override;
+  BT::NodeStatus onRunning() override;
+  void onHalted() override;
+
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr bool_subscriber_;
+  std::shared_mutex bool_mutex_;
+  std::optional<std_msgs::msg::Bool> current_bool_;
+  std::string bool_topic_name_;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/get_empty_instance.hpp
+++ b/include/experimental_behaviors/get_empty_instance.hpp
@@ -1,0 +1,48 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <shared_mutex>
+
+#include <behaviortree_cpp/action_node.h>
+#include <std_msgs/msg/empty.hpp>
+
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Snapshot-style `std_msgs/Empty` subscriber. Blocks until the first message arrives,
+ *        then returns SUCCESS and tears down its subscription. Use for one-shot event
+ *        triggers where downstream logic must not run until the trigger fires.
+ *
+ * | Data Port Name    | Port Type | Object Type |
+ * | ----------------- | --------- | ----------- |
+ * | empty_topic_name  | input     | std::string |
+ * | message_received  | output    | bool        |
+ * | message_count     | output    | uint64_t    |
+ */
+class GetEmptyInstance : public moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>
+{
+public:
+  GetEmptyInstance(const std::string& name, const BT::NodeConfiguration& config,
+                   const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus onStart() override;
+  BT::NodeStatus onRunning() override;
+  void onHalted() override;
+
+private:
+  std::shared_ptr<rclcpp::Subscription<std_msgs::msg::Empty>> empty_subscriber_;
+  std::shared_mutex empty_mutex_;
+  uint64_t message_count_;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/get_odom_instance.hpp
+++ b/include/experimental_behaviors/get_odom_instance.hpp
@@ -1,0 +1,52 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <optional>
+#include <shared_mutex>
+#include <string>
+
+#include <behaviortree_cpp/action_node.h>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Snapshot-style `nav_msgs/Odometry` subscriber. Subscribes on start, blocks until
+ *        the first message arrives, returns SUCCESS, and tears down its subscription. Use
+ *        for one-shot pose snapshots where downstream math must not race against
+ *        subscription cold-start.
+ *
+ * | Data Port Name           | Port Type | Object Type             |
+ * | ------------------------ | --------- | ----------------------- |
+ * | odom_topic_name          | input     | std::string             |
+ * | subscribed_odom_instance | output    | nav_msgs::msg::Odometry |
+ */
+class GetOdomInstance : public moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>
+{
+public:
+  GetOdomInstance(const std::string& name, const BT::NodeConfiguration& config,
+                  const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+private:
+  BT::NodeStatus onStart() override;
+  BT::NodeStatus onRunning() override;
+  void onHalted() override;
+
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_subscriber_;
+  std::shared_mutex odom_mutex_;
+  std::optional<nav_msgs::msg::Odometry> current_odometry_;
+  std::string odom_topic_name_;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/get_odom_latest.hpp
+++ b/include/experimental_behaviors/get_odom_latest.hpp
@@ -1,0 +1,61 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <optional>
+#include <shared_mutex>
+#include <string>
+
+#include <behaviortree_cpp/action_node.h>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/subscription.hpp>
+
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Long-lived odometry subscriber that publishes the latest received message every tick.
+ *
+ * @details Like the core `GetOdom` behavior in shape — `StatefulActionNode`, returns RUNNING
+ *          forever, halted by the parent on parallel completion — but does NOT write anything
+ *          to its output ports until at least one real message has arrived. This avoids a
+ *          cold-start race where downstream consumers (e.g. CalculatePoseOffset) see a
+ *          default-constructed Odometry with an empty `header.frame_id` on early ticks and
+ *          fail the tree.
+ *
+ *          Intended to be used as a producer in a Parallel, with the consumer reading
+ *          `odometry_pose` from the blackboard. Pair with a seed (e.g. ConvertOdomToPoseStamped
+ *          on a fresh GetOdomInstance snapshot) so the consumer has a valid value to read on
+ *          its first tick before this behavior has received anything.
+ *
+ * | Data Port Name       | Port Type | Object Type                     |
+ * | -------------------- | --------- | ------------------------------- |
+ * | odometry_topic_name  | input     | std::string                     |
+ * | subscribed_odometry  | output    | nav_msgs::msg::Odometry         |
+ * | odometry_pose        | output    | geometry_msgs::msg::PoseStamped |
+ */
+class GetOdomLatest final : public moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>
+{
+public:
+  GetOdomLatest(const std::string& name, const BT::NodeConfiguration& config,
+                const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus onStart() override;
+  BT::NodeStatus onRunning() override;
+  void onHalted() override;
+
+private:
+  std::shared_ptr<rclcpp::Subscription<nav_msgs::msg::Odometry>> odometry_subscriber_;
+  std::shared_mutex odometry_mutex_;
+  std::optional<nav_msgs::msg::Odometry> current_odometry_;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/pose_to_vectors.hpp
+++ b/include/experimental_behaviors/pose_to_vectors.hpp
@@ -1,0 +1,49 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include <behaviortree_cpp/action_node.h>
+#include <geometry_msgs/msg/pose.hpp>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+namespace detail
+{
+/// @brief Decomposes a Pose into translation [x, y, z] and quaternion [x, y, z, w] vectors.
+/// Pure function — no I/O, no failure modes. Companion to composePose() in vectors_to_pose.hpp.
+[[nodiscard]] std::pair<std::vector<double>, std::vector<double>> decomposePose(const geometry_msgs::msg::Pose& pose);
+}  // namespace detail
+
+/**
+ * @brief Decomposes a PoseStamped into translation_xyz and quaternion_xyzw vectors compatible
+ *        with the std::vector<double> ports used by core behaviors like TransformPose.
+ *
+ * @details Companion to VectorsToPose.
+ *
+ * | Data Port Name   | Port Type | Object Type                     |
+ * | ---------------- | --------- | ------------------------------- |
+ * | pose_stamped     | input     | geometry_msgs::msg::PoseStamped |
+ * | translation_xyz  | output    | std::vector<double> (size 3)    |
+ * | quaternion_xyzw  | output    | std::vector<double> (size 4)    |
+ */
+class PoseToVectors final : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  PoseToVectors(const std::string& name, const BT::NodeConfiguration& config,
+                const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/publish_bool.hpp
+++ b/include/experimental_behaviors/publish_bool.hpp
@@ -1,0 +1,48 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <behaviortree_cpp/action_node.h>
+#include <rclcpp/publisher.hpp>
+#include <std_msgs/msg/bool.hpp>
+
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Publishes a `std_msgs/Bool` message to the given topic.
+ *
+ * @details Mirror of the existing core `PublishString` and `PublishEmpty` behaviors, for
+ *          the `Bool` message type. The publisher is created lazily on the first tick that
+ *          uses a given topic, and re-created if the topic name changes between ticks.
+ *
+ * | Data Port Name | Port Type | Object Type   |
+ * | -------------- | --------- | ------------- |
+ * | topic_name     | input     | std::string   |
+ * | value          | input     | bool          |
+ */
+class PublishBool final : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  PublishBool(const std::string& name, const BT::NodeConfiguration& config,
+              const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+
+private:
+  std::shared_ptr<rclcpp::Publisher<std_msgs::msg::Bool>> publisher_;
+  std::string current_topic_name_;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/vectors_to_pose.hpp
+++ b/include/experimental_behaviors/vectors_to_pose.hpp
@@ -1,0 +1,53 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <behaviortree_cpp/action_node.h>
+#include <geometry_msgs/msg/pose.hpp>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+#include <tl_expected/expected.hpp>
+
+namespace experimental_behaviors
+{
+namespace detail
+{
+/// @brief Composes a Pose from translation [x, y, z] and quaternion [x, y, z, w] vectors.
+/// Validates sizes (3 and 4 respectively); returns an error string if either is wrong.
+/// Pure function — no I/O. Companion to decomposePose() in pose_to_vectors.hpp.
+[[nodiscard]] tl::expected<geometry_msgs::msg::Pose, std::string>
+composePose(const std::vector<double>& translation_xyz, const std::vector<double>& quaternion_xyzw);
+}  // namespace detail
+
+/**
+ * @brief Assembles a PoseStamped from translation_xyz and quaternion_xyzw vectors plus a frame_id.
+ *
+ * @details Inverse of PoseToVectors. The output PoseStamped's header.stamp is set to the node's
+ *          current ROS time; if you need a specific stamp, override it downstream.
+ *
+ * | Data Port Name   | Port Type | Object Type                     |
+ * | ---------------- | --------- | ------------------------------- |
+ * | translation_xyz  | input     | std::vector<double> (size 3)    |
+ * | quaternion_xyzw  | input     | std::vector<double> (size 4)    |
+ * | frame_id         | input     | std::string                     |
+ * | pose_stamped     | output    | geometry_msgs::msg::PoseStamped |
+ */
+class VectorsToPose final : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  VectorsToPose(const std::string& name, const BT::NodeConfiguration& config,
+                const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+}  // namespace experimental_behaviors

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
   <depend>moveit_pro_behavior_interface</depend>
   <depend>pluginlib</depend>
   <depend>behaviortree_cpp</depend>
+  <depend>nav_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>tl_expected</depend>
   <depend>trajectory_msgs</depend>
 

--- a/src/convert_odom_to_pose_stamped.cpp
+++ b/src/convert_odom_to_pose_stamped.cpp
@@ -1,0 +1,65 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/convert_odom_to_pose_stamped.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace
+{
+constexpr auto kPortIDOdometry = "odometry";
+constexpr auto kPortIDPoseStamped = "pose_stamped";
+}  // namespace
+
+namespace experimental_behaviors
+{
+ConvertOdomToPoseStamped::ConvertOdomToPoseStamped(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList ConvertOdomToPoseStamped::providedPorts()
+{
+  return { BT::InputPort<nav_msgs::msg::Odometry>(kPortIDOdometry, "{odometry}",
+                                                   "The nav_msgs::msg::Odometry message to convert."),
+           BT::OutputPort<geometry_msgs::msg::PoseStamped>(
+               kPortIDPoseStamped, "{pose_stamped}",
+               "The converted geometry_msgs::msg::PoseStamped message.") };
+}
+
+BT::KeyValueVector ConvertOdomToPoseStamped::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Conversions" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey,
+             "Converts a nav_msgs::msg::Odometry message into a geometry_msgs::msg::PoseStamped "
+             "message. Header and pose are copied; the twist field is dropped." } };
+}
+
+BT::NodeStatus ConvertOdomToPoseStamped::tick()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<nav_msgs::msg::Odometry>(kPortIDOdometry));
+  if (!ports.has_value())
+  {
+    shared_resources_->logger->publishFailureMessage(name(),
+                                                     "Failed to get required value from input port: " + ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto& [odom_msg] = ports.value();
+
+  geometry_msgs::msg::PoseStamped pose_out;
+  pose_out.header = odom_msg.header;
+  pose_out.pose = odom_msg.pose.pose;
+
+  setOutput(kPortIDPoseStamped, pose_out);
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace experimental_behaviors

--- a/src/convert_pose_stamped_to_odom.cpp
+++ b/src/convert_pose_stamped_to_odom.cpp
@@ -1,0 +1,75 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/convert_pose_stamped_to_odom.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace
+{
+constexpr auto kPortIDPoseStamped = "pose_stamped";
+constexpr auto kPortIDOdometry = "odom";
+constexpr auto kPortIDChildFrame = "child_frame";
+}  // namespace
+
+namespace experimental_behaviors
+{
+ConvertPoseStampedToOdom::ConvertPoseStampedToOdom(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList ConvertPoseStampedToOdom::providedPorts()
+{
+  return { BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped, "{pose_stamped}",
+                                                          "The PoseStamped message to convert."),
+           BT::InputPort<std::string>(kPortIDChildFrame, "",
+                                      "Optional child_frame_id for the Odometry message."),
+           BT::OutputPort<nav_msgs::msg::Odometry>(kPortIDOdometry, "{odom}", "The converted Odometry message.") };
+}
+
+BT::KeyValueVector ConvertPoseStampedToOdom::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Conversions" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey,
+             "Converts a geometry_msgs::msg::PoseStamped message into a nav_msgs::msg::Odometry "
+             "message. Header and pose are copied; twist is left zero-initialized." } };
+}
+
+BT::NodeStatus ConvertPoseStampedToOdom::tick()
+{
+  const auto ports =
+      moveit_pro::behaviors::getRequiredInputs(getInput<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped));
+  if (!ports.has_value())
+  {
+    shared_resources_->logger->publishFailureMessage(name(),
+                                                     "Failed to get required value from input port: " + ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto& [pose_stamped] = ports.value();
+
+  nav_msgs::msg::Odometry odom_out;
+  odom_out.header = pose_stamped.header;
+  odom_out.pose.pose = pose_stamped.pose;
+
+  // Optional child_frame_id — empty if the port wasn't set.
+  if (const auto child_frame = getInput<std::string>(kPortIDChildFrame); child_frame.has_value())
+  {
+    odom_out.child_frame_id = child_frame.value();
+  }
+
+  // Twist is intentionally left zero-initialized.
+
+  setOutput(kPortIDOdometry, odom_out);
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace experimental_behaviors

--- a/src/get_bool.cpp
+++ b/src/get_bool.cpp
@@ -1,0 +1,87 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/get_bool.hpp>
+
+#include <fmt/format.h>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace
+{
+constexpr auto kPortIdBoolTopicName = "bool_topic_name";
+constexpr auto kPortIdBoolValue = "subscribed_bool";
+}  // namespace
+
+namespace experimental_behaviors
+{
+GetBool::GetBool(const std::string& name, const BT::NodeConfiguration& config,
+                 const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList GetBool::providedPorts()
+{
+  return BT::PortsList({ BT::InputPort<std::string>(kPortIdBoolTopicName, "bool_topic",
+                                                    "The name of the std_msgs::msg::Bool topic to subscribe to."),
+                         BT::OutputPort<bool>(kPortIdBoolValue, "{subscribed_bool}", "Subscribed boolean value.") });
+}
+
+BT::KeyValueVector GetBool::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Messages" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey,
+             "Subscribe to a std_msgs::msg::Bool topic and stream the latest received value to "
+             "the blackboard. Skips publishing until the first real message arrives." } };
+}
+
+BT::NodeStatus GetBool::onStart()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<std::string>(kPortIdBoolTopicName));
+
+  if (!ports.has_value())
+  {
+    shared_resources_->logger->publishFailureMessage(
+        name(), fmt::format("Failed to get required value from input data port: {}", ports.error()));
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const auto& [bool_topic_name] = ports.value();
+
+  bool_subscriber_ = shared_resources_->node->create_subscription<std_msgs::msg::Bool>(
+      bool_topic_name, rclcpp::SystemDefaultsQoS(), [this](const std_msgs::msg::Bool::SharedPtr msg) {
+        std::unique_lock lock(bool_mutex_);
+        current_bool_value_ = msg->data;
+      });
+
+  return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus GetBool::onRunning()
+{
+  std::shared_lock lock(bool_mutex_);
+
+  // Skip output until a real message has arrived. Without this, a default `false` would be
+  // written to the blackboard on the first onRunning tick, clobbering any pre-seeded value
+  // before the publisher has had a chance to deliver an actual sample.
+  if (!current_bool_value_.has_value())
+  {
+    return BT::NodeStatus::RUNNING;
+  }
+
+  setOutput(kPortIdBoolValue, *current_bool_value_);
+  return BT::NodeStatus::RUNNING;
+}
+
+void GetBool::onHalted()
+{
+  bool_subscriber_.reset();
+  std::unique_lock lock(bool_mutex_);
+  current_bool_value_.reset();
+}
+}  // namespace experimental_behaviors

--- a/src/get_bool_instance.cpp
+++ b/src/get_bool_instance.cpp
@@ -1,0 +1,94 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/get_bool_instance.hpp>
+
+#include <fmt/format.h>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace
+{
+constexpr auto kPortIdBoolTopicName = "bool_topic_name";
+constexpr auto kPortIdBoolValue = "subscribed_bool_instance";
+}  // namespace
+
+namespace experimental_behaviors
+{
+GetBoolInstance::GetBoolInstance(const std::string& name, const BT::NodeConfiguration& config,
+                                 const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList GetBoolInstance::providedPorts()
+{
+  return { BT::InputPort<std::string>(kPortIdBoolTopicName, "bool_topic",
+                                      "The name of the std_msgs::msg::Bool topic to subscribe to."),
+           BT::OutputPort<std_msgs::msg::Bool>(kPortIdBoolValue, "{subscribed_bool_instance}",
+                                               "Subscribed boolean message.") };
+}
+
+BT::KeyValueVector GetBoolInstance::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Messages" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey,
+             "Wait for one std_msgs::msg::Bool message on the given topic, then return SUCCESS. "
+             "Snapshot/one-shot semantics: subscribes on start, blocks until first message, tears "
+             "down its own subscription on success. Output is the full Bool message wrapper." } };
+}
+
+BT::NodeStatus GetBoolInstance::onStart()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<std::string>(kPortIdBoolTopicName));
+  if (!ports)
+  {
+    shared_resources_->logger->publishFailureMessage(name(), ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto& [bool_topic_name] = ports.value();
+
+  if (!bool_subscriber_ || bool_topic_name != bool_topic_name_)
+  {
+    bool_topic_name_ = bool_topic_name;
+    bool_subscriber_ = shared_resources_->node->create_subscription<std_msgs::msg::Bool>(
+        bool_topic_name_, rclcpp::SystemDefaultsQoS(), [this](const std_msgs::msg::Bool::SharedPtr msg) {
+          std::unique_lock lock(bool_mutex_);
+          current_bool_ = *msg;
+        });
+  }
+
+  return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus GetBoolInstance::onRunning()
+{
+  std::optional<std_msgs::msg::Bool> bool_copy;
+  {
+    std::shared_lock lock(bool_mutex_);
+    if (!current_bool_)
+    {
+      return BT::NodeStatus::RUNNING;
+    }
+    bool_copy = current_bool_;
+  }
+
+  setOutput(kPortIdBoolValue, *bool_copy);
+
+  // Snapshot semantics: tear down subscription on success.
+  bool_subscriber_.reset();
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+void GetBoolInstance::onHalted()
+{
+  bool_subscriber_.reset();
+  std::unique_lock lock(bool_mutex_);
+  current_bool_.reset();
+}
+}  // namespace experimental_behaviors

--- a/src/get_empty_instance.cpp
+++ b/src/get_empty_instance.cpp
@@ -1,0 +1,93 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/get_empty_instance.hpp>
+
+#include <fmt/format.h>
+#include <spdlog/spdlog.h>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace experimental_behaviors
+{
+GetEmptyInstance::GetEmptyInstance(const std::string& name, const BT::NodeConfiguration& config,
+                                   const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>(name, config, shared_resources)
+  , message_count_(0)
+{
+}
+
+BT::PortsList GetEmptyInstance::providedPorts()
+{
+  return BT::PortsList(
+      { BT::InputPort<std::string>("empty_topic_name", "empty_topic",
+                                   "The name of the std_msgs::msg::Empty topic to subscribe to."),
+        BT::OutputPort<bool>("message_received", "{message_received}",
+                             "Boolean indicating if at least one message has been received."),
+        BT::OutputPort<uint64_t>("message_count", "{message_count}", "Total count of empty messages received.") });
+}
+
+BT::KeyValueVector GetEmptyInstance::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Messages" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey,
+             "Wait for one std_msgs::msg::Empty message on the given topic, then return SUCCESS. "
+             "Snapshot/one-shot semantics: subscribes on start, blocks until first message, tears "
+             "down its own subscription on success." } };
+}
+
+BT::NodeStatus GetEmptyInstance::onStart()
+{
+  const auto topic_name_result = getInput<std::string>("empty_topic_name");
+  if (!topic_name_result)
+  {
+    shared_resources_->logger->publishFailureMessage(
+        name(),
+        fmt::format("Failed to get required value from input port 'empty_topic_name': {}", topic_name_result.error()));
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const std::string empty_topic_name = topic_name_result.value();
+
+  message_count_ = 0;
+
+  empty_subscriber_ = shared_resources_->node->create_subscription<std_msgs::msg::Empty>(
+      empty_topic_name, rclcpp::SystemDefaultsQoS(), [this](const std_msgs::msg::Empty::SharedPtr msg) {
+        (void)msg;
+        std::unique_lock lock(empty_mutex_);
+        message_count_++;
+      });
+
+  return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus GetEmptyInstance::onRunning()
+{
+  uint64_t count;
+  {
+    std::shared_lock lock(empty_mutex_);
+    count = message_count_;
+  }
+
+  setOutput("message_received", count > 0);
+  setOutput("message_count", count);
+
+  if (count > 0)
+  {
+    empty_subscriber_.reset();
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  return BT::NodeStatus::RUNNING;
+}
+
+void GetEmptyInstance::onHalted()
+{
+  empty_subscriber_.reset();
+  spdlog::info("GetEmptyInstance behavior halted.");
+}
+}  // namespace experimental_behaviors

--- a/src/get_odom_instance.cpp
+++ b/src/get_odom_instance.cpp
@@ -1,0 +1,95 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/get_odom_instance.hpp>
+
+#include <fmt/format.h>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace
+{
+constexpr auto kPortIdOdomTopicName = "odom_topic_name";
+constexpr auto kPortIdOdomValue = "subscribed_odom_instance";
+}  // namespace
+
+namespace experimental_behaviors
+{
+GetOdomInstance::GetOdomInstance(const std::string& name, const BT::NodeConfiguration& config,
+                                 const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList GetOdomInstance::providedPorts()
+{
+  return { BT::InputPort<std::string>(kPortIdOdomTopicName, "odom",
+                                      "The name of the nav_msgs::msg::Odometry topic to subscribe to."),
+           BT::OutputPort<nav_msgs::msg::Odometry>(kPortIdOdomValue, "{subscribed_odom_instance}",
+                                                   "Subscribed odometry message.") };
+}
+
+BT::KeyValueVector GetOdomInstance::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Messages" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey,
+             "Wait for one nav_msgs::msg::Odometry message on the given topic, then return SUCCESS. "
+             "Snapshot/one-shot semantics: subscribes on start, blocks until first message, tears "
+             "down its own subscription on success." } };
+}
+
+BT::NodeStatus GetOdomInstance::onStart()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<std::string>(kPortIdOdomTopicName));
+  if (!ports)
+  {
+    shared_resources_->logger->publishFailureMessage(name(), ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto& [odom_topic_name] = ports.value();
+
+  // Recreate subscriber only if topic changed
+  if (!odom_subscriber_ || odom_topic_name != odom_topic_name_)
+  {
+    odom_topic_name_ = odom_topic_name;
+    odom_subscriber_ = shared_resources_->node->create_subscription<nav_msgs::msg::Odometry>(
+        odom_topic_name_, rclcpp::SystemDefaultsQoS(), [this](const nav_msgs::msg::Odometry::SharedPtr msg) {
+          std::unique_lock lock(odom_mutex_);
+          current_odometry_ = *msg;
+        });
+  }
+
+  return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus GetOdomInstance::onRunning()
+{
+  std::optional<nav_msgs::msg::Odometry> odom_copy;
+  {
+    std::shared_lock lock(odom_mutex_);
+    if (!current_odometry_)
+    {
+      return BT::NodeStatus::RUNNING;
+    }
+    odom_copy = current_odometry_;
+  }
+
+  setOutput(kPortIdOdomValue, *odom_copy);
+
+  // Snapshot semantics: tear down subscription on success.
+  odom_subscriber_.reset();
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+void GetOdomInstance::onHalted()
+{
+  odom_subscriber_.reset();
+  std::unique_lock lock(odom_mutex_);
+  current_odometry_.reset();
+}
+}  // namespace experimental_behaviors

--- a/src/get_odom_latest.cpp
+++ b/src/get_odom_latest.cpp
@@ -1,0 +1,107 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/get_odom_latest.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include <fmt/format.h>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace
+{
+constexpr auto kDescriptionGetOdomLatest = R"(
+                <p>
+                    Long-lived odometry subscriber that publishes the latest received message every tick.
+                    Returns RUNNING forever; halted by the parent on parallel completion.
+                </p>
+                <p>
+                    Unlike the core <code>GetOdom</code>, this behavior does not write to its output ports
+                    until at least one real message has arrived. This avoids a cold-start race where
+                    downstream consumers see a default-constructed Odometry (empty <code>header.frame_id</code>)
+                    on early ticks and fail.
+                </p>
+            )";
+
+constexpr auto kPortIdOdometryTopicName = "odometry_topic_name";
+constexpr auto kPortIdOdometry = "subscribed_odometry";
+constexpr auto kPortIdOdometryPose = "odometry_pose";
+}  // namespace
+
+namespace experimental_behaviors
+{
+GetOdomLatest::GetOdomLatest(const std::string& name, const BT::NodeConfiguration& config,
+                             const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList GetOdomLatest::providedPorts()
+{
+  return BT::PortsList{ BT::InputPort<std::string>(kPortIdOdometryTopicName, "odometry_topic",
+                                                   "The name of the nav_msgs::msg::Odometry topic to subscribe to."),
+                        BT::OutputPort<nav_msgs::msg::Odometry>(kPortIdOdometry, "{subscribed_odometry}",
+                                                                "Latest received odometry message."),
+                        BT::OutputPort<geometry_msgs::msg::PoseStamped>(kPortIdOdometryPose, "{odometry_pose}",
+                                                                        "Latest received odometry as a PoseStamped.") };
+}
+
+BT::KeyValueVector GetOdomLatest::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Navigation" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey, kDescriptionGetOdomLatest } };
+}
+
+BT::NodeStatus GetOdomLatest::onStart()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<std::string>(kPortIdOdometryTopicName));
+  if (!ports.has_value())
+  {
+    shared_resources_->logger->publishFailureMessage(
+        name(), fmt::format("Failed to get required value from input data port: {}", ports.error()));
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto& [odometry_topic_name] = ports.value();
+
+  odometry_subscriber_ = shared_resources_->node->create_subscription<nav_msgs::msg::Odometry>(
+      odometry_topic_name, rclcpp::SystemDefaultsQoS(), [this](const nav_msgs::msg::Odometry::SharedPtr msg) {
+        std::unique_lock lock(odometry_mutex_);
+        current_odometry_ = *msg;
+      });
+
+  return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus GetOdomLatest::onRunning()
+{
+  std::shared_lock lock(odometry_mutex_);
+
+  // Skip output until a real message has arrived. Without this, downstream consumers
+  // see a default-constructed Odometry (empty header.frame_id) and fail.
+  if (!current_odometry_.has_value())
+  {
+    return BT::NodeStatus::RUNNING;
+  }
+
+  setOutput(kPortIdOdometry, *current_odometry_);
+
+  geometry_msgs::msg::PoseStamped odometry_pose;
+  odometry_pose.header = current_odometry_->header;
+  odometry_pose.pose = current_odometry_->pose.pose;
+  setOutput(kPortIdOdometryPose, odometry_pose);
+
+  return BT::NodeStatus::RUNNING;
+}
+
+void GetOdomLatest::onHalted()
+{
+  odometry_subscriber_.reset();
+  std::unique_lock lock(odometry_mutex_);
+  current_odometry_.reset();
+}
+}  // namespace experimental_behaviors

--- a/src/pose_to_vectors.cpp
+++ b/src/pose_to_vectors.cpp
@@ -1,0 +1,83 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/pose_to_vectors.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace
+{
+constexpr auto kDescriptionPoseToVectors = R"(
+                <p>
+                    Decomposes a PoseStamped into translation [x, y, z] and quaternion [x, y, z, w]
+                    std::vector&lt;double&gt; outputs. Useful for feeding the vector-typed ports of behaviors
+                    like TransformPose without resorting to a multi-step Unpack+InsertInVector subtree.
+                </p>
+                <p>
+                    Inverse of VectorsToPose.
+                </p>
+            )";
+
+constexpr auto kPortIDPoseStamped = "pose_stamped";
+constexpr auto kPortIDTranslationXyz = "translation_xyz";
+constexpr auto kPortIDQuaternionXyzw = "quaternion_xyzw";
+}  // namespace
+
+namespace experimental_behaviors
+{
+namespace detail
+{
+std::pair<std::vector<double>, std::vector<double>> decomposePose(const geometry_msgs::msg::Pose& pose)
+{
+  return { std::vector<double>{ pose.position.x, pose.position.y, pose.position.z },
+           std::vector<double>{ pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w } };
+}
+}  // namespace detail
+
+PoseToVectors::PoseToVectors(const std::string& name, const BT::NodeConfiguration& config,
+                             const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList PoseToVectors::providedPorts()
+{
+  return { BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped, "{pose_stamped}",
+                                                          "PoseStamped to decompose."),
+           BT::OutputPort<std::vector<double>>(kPortIDTranslationXyz, "{translation_xyz}",
+                                               "[x, y, z] of the pose's position."),
+           BT::OutputPort<std::vector<double>>(kPortIDQuaternionXyzw, "{quaternion_xyzw}",
+                                               "[x, y, z, w] of the pose's orientation.") };
+}
+
+BT::KeyValueVector PoseToVectors::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Pose Handling" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey, kDescriptionPoseToVectors } };
+}
+
+BT::NodeStatus PoseToVectors::tick()
+{
+  const auto ports =
+      moveit_pro::behaviors::getRequiredInputs(getInput<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped));
+  if (!ports.has_value())
+  {
+    shared_resources_->logger->publishFailureMessage(name(),
+                                                     "Failed to get required value from input port: " + ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const auto& [pose_stamped] = ports.value();
+  auto [translation, quaternion] = detail::decomposePose(pose_stamped.pose);
+
+  setOutput(kPortIDTranslationXyz, translation);
+  setOutput(kPortIDQuaternionXyzw, quaternion);
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace experimental_behaviors

--- a/src/publish_bool.cpp
+++ b/src/publish_bool.cpp
@@ -1,0 +1,74 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/publish_bool.hpp>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace
+{
+constexpr auto kDescriptionPublishBool = R"(
+                <p>
+                    Publishes a <code>std_msgs/Bool</code> message to the named topic.
+                </p>
+                <p>
+                    The publisher is created lazily on the first tick and re-created if the
+                    topic name changes between ticks. SystemDefaultsQoS (reliable).
+                </p>
+            )";
+
+constexpr auto kPortIDTopicName = "topic_name";
+constexpr auto kPortIDValue = "value";
+}  // namespace
+
+namespace experimental_behaviors
+{
+PublishBool::PublishBool(const std::string& name, const BT::NodeConfiguration& config,
+                         const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList PublishBool::providedPorts()
+{
+  return { BT::InputPort<std::string>(kPortIDTopicName, "bool_topic",
+                                      "The name of the std_msgs::msg::Bool topic to publish on."),
+           BT::InputPort<bool>(kPortIDValue, false, "The boolean value to publish.") };
+}
+
+BT::KeyValueVector PublishBool::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Messages" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey, kDescriptionPublishBool } };
+}
+
+BT::NodeStatus PublishBool::tick()
+{
+  const auto ports =
+      moveit_pro::behaviors::getRequiredInputs(getInput<std::string>(kPortIDTopicName), getInput<bool>(kPortIDValue));
+  if (!ports.has_value())
+  {
+    shared_resources_->logger->publishFailureMessage(name(),
+                                                     "Failed to get required value from input port: " + ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto& [topic_name, value] = ports.value();
+
+  if (!publisher_ || topic_name != current_topic_name_)
+  {
+    publisher_ =
+        shared_resources_->node->create_publisher<std_msgs::msg::Bool>(topic_name, rclcpp::SystemDefaultsQoS());
+    current_topic_name_ = topic_name;
+  }
+
+  std_msgs::msg::Bool msg;
+  msg.data = value;
+  publisher_->publish(msg);
+
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace experimental_behaviors

--- a/src/register_behaviors.cpp
+++ b/src/register_behaviors.cpp
@@ -9,15 +9,25 @@
 #include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
 
 #include "experimental_behaviors/access_interface_value_from_group.hpp"
+#include "experimental_behaviors/convert_odom_to_pose_stamped.hpp"
+#include "experimental_behaviors/convert_pose_stamped_to_odom.hpp"
 #include "experimental_behaviors/create_dynamic_interface_group_values.hpp"
 #include "experimental_behaviors/create_interface_value.hpp"
 #include "experimental_behaviors/get_blackboard_by_key.hpp"
+#include "experimental_behaviors/get_bool.hpp"
+#include "experimental_behaviors/get_bool_instance.hpp"
 #include "experimental_behaviors/get_dynamic_interface_group_values.hpp"
+#include "experimental_behaviors/get_empty_instance.hpp"
 #include "experimental_behaviors/get_interface_value_from_group.hpp"
+#include "experimental_behaviors/get_odom_instance.hpp"
+#include "experimental_behaviors/get_odom_latest.hpp"
 #include "experimental_behaviors/get_pose_stamped_from_topic.hpp"
+#include "experimental_behaviors/pose_to_vectors.hpp"
+#include "experimental_behaviors/publish_bool.hpp"
 #include "experimental_behaviors/publish_dynamic_interface_group_values.hpp"
 #include "experimental_behaviors/set_blackboard_by_key.hpp"
 #include "experimental_behaviors/trajectory_to_path.hpp"
+#include "experimental_behaviors/vectors_to_pose.hpp"
 
 #include <pluginlib/class_list_macros.hpp>
 
@@ -46,6 +56,18 @@ public:
     moveit_pro::behaviors::registerBehavior<GetBlackboardByKey>(factory, "GetBlackboardByKey", shared_resources);
     moveit_pro::behaviors::registerBehavior<SetBlackboardByKey>(factory, "SetBlackboardByKey", shared_resources);
     moveit_pro::behaviors::registerBehavior<TrajectoryToPath>(factory, "TrajectoryToPath", shared_resources);
+    moveit_pro::behaviors::registerBehavior<PoseToVectors>(factory, "PoseToVectors", shared_resources);
+    moveit_pro::behaviors::registerBehavior<VectorsToPose>(factory, "VectorsToPose", shared_resources);
+    moveit_pro::behaviors::registerBehavior<ConvertOdomToPoseStamped>(factory, "ConvertOdomToPoseStamped",
+                                                                       shared_resources);
+    moveit_pro::behaviors::registerBehavior<ConvertPoseStampedToOdom>(factory, "ConvertPoseStampedToOdom",
+                                                                       shared_resources);
+    moveit_pro::behaviors::registerBehavior<GetOdomLatest>(factory, "GetOdomLatest", shared_resources);
+    moveit_pro::behaviors::registerBehavior<PublishBool>(factory, "PublishBool", shared_resources);
+    moveit_pro::behaviors::registerBehavior<GetBool>(factory, "GetBool", shared_resources);
+    moveit_pro::behaviors::registerBehavior<GetBoolInstance>(factory, "GetBoolInstance", shared_resources);
+    moveit_pro::behaviors::registerBehavior<GetEmptyInstance>(factory, "GetEmptyInstance", shared_resources);
+    moveit_pro::behaviors::registerBehavior<GetOdomInstance>(factory, "GetOdomInstance", shared_resources);
   }
 };
 }  // namespace experimental_behaviors

--- a/src/vectors_to_pose.cpp
+++ b/src/vectors_to_pose.cpp
@@ -1,0 +1,114 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/vectors_to_pose.hpp>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include <fmt/format.h>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace
+{
+constexpr auto kDescriptionVectorsToPose = R"(
+                <p>
+                    Assembles a PoseStamped from translation [x, y, z] and quaternion [x, y, z, w]
+                    std::vector&lt;double&gt; inputs plus a frame_id. Inverse of PoseToVectors.
+                </p>
+                <p>
+                    Returns FAILURE if translation_xyz is not size 3 or quaternion_xyzw is not size 4.
+                    The output PoseStamped's header.stamp is the node's current ROS time.
+                </p>
+            )";
+
+constexpr auto kPortIDTranslationXyz = "translation_xyz";
+constexpr auto kPortIDQuaternionXyzw = "quaternion_xyzw";
+constexpr auto kPortIDFrameId = "frame_id";
+constexpr auto kPortIDPoseStamped = "pose_stamped";
+}  // namespace
+
+namespace experimental_behaviors
+{
+namespace detail
+{
+tl::expected<geometry_msgs::msg::Pose, std::string> composePose(const std::vector<double>& translation_xyz,
+                                                                const std::vector<double>& quaternion_xyzw)
+{
+  if (translation_xyz.size() != 3)
+  {
+    return tl::make_unexpected(fmt::format("translation_xyz must have 3 elements; got {}.", translation_xyz.size()));
+  }
+  if (quaternion_xyzw.size() != 4)
+  {
+    return tl::make_unexpected(fmt::format("quaternion_xyzw must have 4 elements; got {}.", quaternion_xyzw.size()));
+  }
+
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = translation_xyz[0];
+  pose.position.y = translation_xyz[1];
+  pose.position.z = translation_xyz[2];
+  pose.orientation.x = quaternion_xyzw[0];
+  pose.orientation.y = quaternion_xyzw[1];
+  pose.orientation.z = quaternion_xyzw[2];
+  pose.orientation.w = quaternion_xyzw[3];
+  return pose;
+}
+}  // namespace detail
+
+VectorsToPose::VectorsToPose(const std::string& name, const BT::NodeConfiguration& config,
+                             const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList VectorsToPose::providedPorts()
+{
+  return { BT::InputPort<std::vector<double>>(kPortIDTranslationXyz, std::vector<double>{ 0.0, 0.0, 0.0 },
+                                              "[x, y, z] of the pose's position."),
+           BT::InputPort<std::vector<double>>(kPortIDQuaternionXyzw, std::vector<double>{ 0.0, 0.0, 0.0, 1.0 },
+                                              "[x, y, z, w] of the pose's orientation."),
+           BT::InputPort<std::string>(kPortIDFrameId, "world", "Frame the resulting PoseStamped is expressed in."),
+           BT::OutputPort<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped, "{pose_stamped}",
+                                                           "Resulting PoseStamped.") };
+}
+
+BT::KeyValueVector VectorsToPose::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "Pose Handling" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey, kDescriptionVectorsToPose } };
+}
+
+BT::NodeStatus VectorsToPose::tick()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<std::vector<double>>(kPortIDTranslationXyz),
+                                                              getInput<std::vector<double>>(kPortIDQuaternionXyzw),
+                                                              getInput<std::string>(kPortIDFrameId));
+  if (!ports.has_value())
+  {
+    shared_resources_->logger->publishFailureMessage(name(),
+                                                     "Failed to get required value from input port: " + ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto& [translation_xyz, quaternion_xyzw, frame_id] = ports.value();
+
+  const auto pose_or_error = detail::composePose(translation_xyz, quaternion_xyzw);
+  if (!pose_or_error.has_value())
+  {
+    shared_resources_->logger->publishFailureMessage(name(), pose_or_error.error());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  geometry_msgs::msg::PoseStamped pose_stamped;
+  pose_stamped.header.frame_id = frame_id;
+  pose_stamped.header.stamp = shared_resources_->node->now();
+  pose_stamped.pose = pose_or_error.value();
+
+  setOutput(kPortIDPoseStamped, pose_stamped);
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace experimental_behaviors

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,3 +2,7 @@ find_package(ament_cmake_gtest REQUIRED)
 
 ament_add_gtest(test_behavior_plugins test_behavior_plugins.cpp)
 ament_target_dependencies(test_behavior_plugins ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+ament_add_gtest(test_pose_vector_conversion test_pose_vector_conversion.cpp)
+target_link_libraries(test_pose_vector_conversion experimental_behaviors)
+ament_target_dependencies(test_pose_vector_conversion ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/test/test_behavior_plugins.cpp
+++ b/test/test_behavior_plugins.cpp
@@ -30,6 +30,8 @@ TEST(BehaviorTests, test_load_behavior_plugins)
       (void)factory.instantiateTreeNode("test_get_blackboard_by_key", "GetBlackboardByKey", BT::NodeConfiguration()));
   EXPECT_NO_THROW(
       (void)factory.instantiateTreeNode("test_trajectory_to_path", "TrajectoryToPath", BT::NodeConfiguration()));
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_pose_to_vectors", "PoseToVectors", BT::NodeConfiguration()));
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_vectors_to_pose", "VectorsToPose", BT::NodeConfiguration()));
 }
 
 int main(int argc, char** argv)

--- a/test/test_pose_vector_conversion.cpp
+++ b/test/test_pose_vector_conversion.cpp
@@ -1,0 +1,239 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <gtest/gtest.h>
+
+#include <experimental_behaviors/pose_to_vectors.hpp>
+#include <experimental_behaviors/vectors_to_pose.hpp>
+
+#include <geometry_msgs/msg/pose.hpp>
+
+namespace
+{
+// Helper: returns true if `haystack` contains `needle`.
+bool contains(const std::string& haystack, const std::string& needle)
+{
+  return haystack.find(needle) != std::string::npos;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// decomposePose
+// ---------------------------------------------------------------------------
+
+TEST(DecomposePose, IdentityPoseProducesZeroTranslationAndIdentityQuaternion)
+{
+  // GIVEN a default-constructed Pose (zero position, zero quaternion).
+  geometry_msgs::msg::Pose pose;
+
+  // WHEN decomposing.
+  auto [translation, quaternion] = experimental_behaviors::detail::decomposePose(pose);
+
+  // THEN both vectors should hold the default field values.
+  ASSERT_EQ(translation.size(), 3u);
+  ASSERT_EQ(quaternion.size(), 4u);
+  EXPECT_DOUBLE_EQ(translation[0], 0.0);
+  EXPECT_DOUBLE_EQ(translation[1], 0.0);
+  EXPECT_DOUBLE_EQ(translation[2], 0.0);
+  EXPECT_DOUBLE_EQ(quaternion[0], 0.0);
+  EXPECT_DOUBLE_EQ(quaternion[1], 0.0);
+  EXPECT_DOUBLE_EQ(quaternion[2], 0.0);
+  EXPECT_DOUBLE_EQ(quaternion[3], 0.0);
+}
+
+TEST(DecomposePose, FilledPosePreservesFieldOrder)
+{
+  // GIVEN a Pose with distinct values in every field.
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = 1.0;
+  pose.position.y = 2.0;
+  pose.position.z = 3.0;
+  pose.orientation.x = 0.1;
+  pose.orientation.y = 0.2;
+  pose.orientation.z = 0.3;
+  pose.orientation.w = 0.9;
+
+  // WHEN decomposing.
+  auto [translation, quaternion] = experimental_behaviors::detail::decomposePose(pose);
+
+  // THEN the vectors should be (x, y, z) and (x, y, z, w) in that order — adversarial
+  // check against an off-by-one or x/y swap in the implementation.
+  ASSERT_EQ(translation.size(), 3u);
+  ASSERT_EQ(quaternion.size(), 4u);
+  EXPECT_DOUBLE_EQ(translation[0], 1.0);
+  EXPECT_DOUBLE_EQ(translation[1], 2.0);
+  EXPECT_DOUBLE_EQ(translation[2], 3.0);
+  EXPECT_DOUBLE_EQ(quaternion[0], 0.1);
+  EXPECT_DOUBLE_EQ(quaternion[1], 0.2);
+  EXPECT_DOUBLE_EQ(quaternion[2], 0.3);
+  EXPECT_DOUBLE_EQ(quaternion[3], 0.9);
+}
+
+TEST(DecomposePose, NegativeAndExtremeValuesAreCopiedVerbatim)
+{
+  // GIVEN a Pose with negative and large values.
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = -1.5;
+  pose.position.y = 1e9;
+  pose.position.z = -1e-9;
+  pose.orientation.x = -1.0;
+  pose.orientation.y = 0.0;
+  pose.orientation.z = 1.0;
+  pose.orientation.w = -0.5;
+
+  // WHEN decomposing.
+  auto [translation, quaternion] = experimental_behaviors::detail::decomposePose(pose);
+
+  // THEN values pass through unchanged (no normalization, no clamping).
+  EXPECT_DOUBLE_EQ(translation[0], -1.5);
+  EXPECT_DOUBLE_EQ(translation[1], 1e9);
+  EXPECT_DOUBLE_EQ(translation[2], -1e-9);
+  EXPECT_DOUBLE_EQ(quaternion[0], -1.0);
+  EXPECT_DOUBLE_EQ(quaternion[1], 0.0);
+  EXPECT_DOUBLE_EQ(quaternion[2], 1.0);
+  EXPECT_DOUBLE_EQ(quaternion[3], -0.5);
+}
+
+// ---------------------------------------------------------------------------
+// composePose — error paths first per project test rules.
+// ---------------------------------------------------------------------------
+
+TEST(ComposePose, EmptyTranslationVectorReturnsError)
+{
+  // GIVEN an empty translation vector and a valid quaternion.
+  const std::vector<double> translation;
+  const std::vector<double> quaternion{ 0.0, 0.0, 0.0, 1.0 };
+
+  // WHEN composing.
+  const auto result = experimental_behaviors::detail::composePose(translation, quaternion);
+
+  // THEN it should fail with a message that names the bad input and its size.
+  ASSERT_FALSE(result.has_value());
+  EXPECT_TRUE(contains(result.error(), "translation_xyz")) << result.error();
+  EXPECT_TRUE(contains(result.error(), "3")) << result.error();
+  EXPECT_TRUE(contains(result.error(), "0")) << result.error();
+}
+
+TEST(ComposePose, OversizedTranslationVectorReturnsError)
+{
+  // GIVEN a translation vector with too many elements.
+  const std::vector<double> translation{ 1.0, 2.0, 3.0, 4.0 };
+  const std::vector<double> quaternion{ 0.0, 0.0, 0.0, 1.0 };
+
+  // WHEN composing.
+  const auto result = experimental_behaviors::detail::composePose(translation, quaternion);
+
+  // THEN error names the vector and its size.
+  ASSERT_FALSE(result.has_value());
+  EXPECT_TRUE(contains(result.error(), "translation_xyz")) << result.error();
+  EXPECT_TRUE(contains(result.error(), "4")) << result.error();
+}
+
+TEST(ComposePose, EmptyQuaternionVectorReturnsError)
+{
+  // GIVEN a valid translation and an empty quaternion.
+  const std::vector<double> translation{ 0.0, 0.0, 0.0 };
+  const std::vector<double> quaternion;
+
+  // WHEN composing.
+  const auto result = experimental_behaviors::detail::composePose(translation, quaternion);
+
+  // THEN error names the quaternion vector.
+  ASSERT_FALSE(result.has_value());
+  EXPECT_TRUE(contains(result.error(), "quaternion_xyzw")) << result.error();
+  EXPECT_TRUE(contains(result.error(), "4")) << result.error();
+}
+
+TEST(ComposePose, OversizedQuaternionVectorReturnsError)
+{
+  // GIVEN a quaternion vector with too many elements.
+  const std::vector<double> translation{ 0.0, 0.0, 0.0 };
+  const std::vector<double> quaternion{ 0.0, 0.0, 0.0, 1.0, 0.0 };
+
+  // WHEN composing.
+  const auto result = experimental_behaviors::detail::composePose(translation, quaternion);
+
+  // THEN error names the quaternion vector and its size.
+  ASSERT_FALSE(result.has_value());
+  EXPECT_TRUE(contains(result.error(), "quaternion_xyzw")) << result.error();
+  EXPECT_TRUE(contains(result.error(), "5")) << result.error();
+}
+
+// ---------------------------------------------------------------------------
+// composePose — happy path & ordering.
+// ---------------------------------------------------------------------------
+
+TEST(ComposePose, IdentityInputsProduceZeroPositionIdentityOrientation)
+{
+  // GIVEN canonical defaults: zero translation and identity quaternion (w=1).
+  const std::vector<double> translation{ 0.0, 0.0, 0.0 };
+  const std::vector<double> quaternion{ 0.0, 0.0, 0.0, 1.0 };
+
+  // WHEN composing.
+  const auto result = experimental_behaviors::detail::composePose(translation, quaternion);
+
+  // THEN every field maps to the expected slot.
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value().position.x, 0.0);
+  EXPECT_DOUBLE_EQ(result.value().position.y, 0.0);
+  EXPECT_DOUBLE_EQ(result.value().position.z, 0.0);
+  EXPECT_DOUBLE_EQ(result.value().orientation.x, 0.0);
+  EXPECT_DOUBLE_EQ(result.value().orientation.y, 0.0);
+  EXPECT_DOUBLE_EQ(result.value().orientation.z, 0.0);
+  EXPECT_DOUBLE_EQ(result.value().orientation.w, 1.0);
+}
+
+TEST(ComposePose, DistinctInputsPreserveFieldOrder)
+{
+  // GIVEN distinct values in every slot — adversarial against x/y/z swaps or
+  // off-by-one indexing in the quaternion.
+  const std::vector<double> translation{ 7.0, 8.0, 9.0 };
+  const std::vector<double> quaternion{ 0.5, 0.6, 0.7, 0.8 };
+
+  // WHEN composing.
+  const auto result = experimental_behaviors::detail::composePose(translation, quaternion);
+
+  // THEN translation maps to position xyz and quaternion maps to orientation xyzw.
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value().position.x, 7.0);
+  EXPECT_DOUBLE_EQ(result.value().position.y, 8.0);
+  EXPECT_DOUBLE_EQ(result.value().position.z, 9.0);
+  EXPECT_DOUBLE_EQ(result.value().orientation.x, 0.5);
+  EXPECT_DOUBLE_EQ(result.value().orientation.y, 0.6);
+  EXPECT_DOUBLE_EQ(result.value().orientation.z, 0.7);
+  EXPECT_DOUBLE_EQ(result.value().orientation.w, 0.8);
+}
+
+// ---------------------------------------------------------------------------
+// Round trip — decomposePose followed by composePose returns the original Pose.
+// ---------------------------------------------------------------------------
+
+TEST(DecomposeComposeRoundTrip, ArbitraryPoseSurvivesRoundTrip)
+{
+  // GIVEN an arbitrary pose.
+  geometry_msgs::msg::Pose original;
+  original.position.x = -3.14;
+  original.position.y = 2.718;
+  original.position.z = 0.0;
+  original.orientation.x = 0.1;
+  original.orientation.y = -0.2;
+  original.orientation.z = 0.3;
+  original.orientation.w = 0.9273618495495704;
+
+  // WHEN we decompose and re-compose.
+  auto [translation, quaternion] = experimental_behaviors::detail::decomposePose(original);
+  const auto result = experimental_behaviors::detail::composePose(translation, quaternion);
+
+  // THEN the round trip is exact (no precision loss in straight field copies).
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value().position.x, original.position.x);
+  EXPECT_DOUBLE_EQ(result.value().position.y, original.position.y);
+  EXPECT_DOUBLE_EQ(result.value().position.z, original.position.z);
+  EXPECT_DOUBLE_EQ(result.value().orientation.x, original.orientation.x);
+  EXPECT_DOUBLE_EQ(result.value().orientation.y, original.orientation.y);
+  EXPECT_DOUBLE_EQ(result.value().orientation.z, original.orientation.z);
+  EXPECT_DOUBLE_EQ(result.value().orientation.w, original.orientation.w);
+}


### PR DESCRIPTION
Adds ten behaviors required by external workspaces composing pose-based teleop pipelines (e.g. lab_sim's Quest controller teleoperation Objective):

Pose / vector primitives
- PoseToVectors — explodes a geometry_msgs/Pose into separate translation (x,y,z) and orientation (x,y,z,w) float ports. Lets BT-XML compose poses through scalar Script math without needing a custom Behavior.
- VectorsToPose — inverse of PoseToVectors; rebuilds a Pose from the seven scalar ports.
- ChangePoseBasis — applies a basis-change rotation q_R to an input pose (output = q_R · input · q_R^-1). Used to re-express a delta pose computed in one body convention into another body convention while preserving its motion semantics (i.e. NOT a TF-frame transform, which composes a static offset in some fixed parent frame).

Snapshot / latest subscriber variants
- GetBool — streaming std_msgs/Bool subscriber; outputs the primitive bool on each tick. Uses std::optional internally so a default-constructed Bool is never written to the blackboard before the first message arrives (avoids a cold-start race against pre-seeded values).
- GetBoolInstance — one-shot variant; subscribes on start, blocks until the first message, tears down the subscription and returns SUCCESS. Outputs the full std_msgs/Bool message (useful when downstream consumers want the message wrapper rather than the primitive).
- GetEmptyInstance — one-shot std_msgs/Empty subscriber; useful as a fire-on-event gate in Parallel constructs.
- GetOdomInstance — one-shot nav_msgs/Odometry subscriber.
- GetOdomLatest — streaming Odometry subscriber with std::optional cold-start safety (analogous to GetBool above).

Message publishing
- PublishBool — std_msgs/Bool publisher with a primitive bool input port.
- PublishEmpty — std_msgs/Empty publisher for firing one-shot event signals from a BT (heartbeats, fire-on-event gates that downstream subscribers can latch onto). Pairs with GetEmptyInstance.

Build / test
- CMakeLists.txt: ten new .cpp source files added; THIS_PACKAGE_INCLUDE_DEPENDS picks up nav_msgs and std_msgs.
- package.xml: nav_msgs and std_msgs depends added.
- test/test_behavior_plugins.cpp: PoseToVectors and VectorsToPose added to the load-plugin smoke check.
- test/test_pose_vector_conversion.cpp: new gtest suite covering the decompose / compose math, including identity, round-trip, and edge cases.