### PR TITLE
feat(yaml-ops): add WriteYamlValue and AppendYamlListItem behaviors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,16 @@ project(experimental_behaviors CXX)
 find_package(moveit_studio_common REQUIRED)
 moveit_studio_package()
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS control_msgs geometry_msgs moveit_pro_behavior_interface pluginlib moveit_studio_common behaviortree_cpp tl_expected trajectory_msgs moveit_pro_base)
+set(THIS_PACKAGE_INCLUDE_DEPENDS ament_index_cpp control_msgs geometry_msgs moveit_pro_behavior_interface pluginlib moveit_studio_common behaviortree_cpp tl_expected trajectory_msgs moveit_pro_base)
 foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${package} REQUIRED)
 endforeach()
+find_package(yaml-cpp REQUIRED)
 
 add_library(
   experimental_behaviors
   SHARED
+  src/append_yaml_list_item.cpp
   src/create_interface_value.cpp
   src/create_dynamic_interface_group_values.cpp
   src/get_dynamic_interface_group_values.cpp
@@ -22,11 +24,13 @@ add_library(
   src/get_blackboard_by_key.cpp
   src/set_blackboard_by_key.cpp
   src/trajectory_to_path.cpp
+  src/write_yaml_value.cpp
   src/register_behaviors.cpp)
 target_include_directories(
   experimental_behaviors
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include>)
+target_link_libraries(experimental_behaviors yaml-cpp)
 ament_target_dependencies(experimental_behaviors
                           ${THIS_PACKAGE_INCLUDE_DEPENDS})
 

--- a/include/experimental_behaviors/append_yaml_list_item.hpp
+++ b/include/experimental_behaviors/append_yaml_list_item.hpp
@@ -1,0 +1,48 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Appends a value to a sequence at a nested key path in a YAML
+ * file. Companion to `WriteYamlValue` (which sets) and `ReadYamlList`
+ * (which reads). Reads don't mutate, so there is no read-side mirror
+ * for "append" specifically.
+ *
+ * | Data Port Name | Port Type | Object Type  |
+ * | -------------- | --------- | ------------ |
+ * | file_path      | input     | std::string  |
+ * | key1           | input     | std::string  |
+ * | key2..key5     | input     | std::string  |
+ * | value          | input     | std::string  |
+ *
+ * Same `key1`–`key5` port shape as `WriteYamlValue` / `ReadYamlList`.
+ * The keyed location must either be absent (a new sequence is
+ * created) or already be a sequence; appending into a scalar or map
+ * fails the tick. The `value` port is parsed as YAML before being
+ * appended, so scalars and inline maps both work.
+ *
+ * Round-trips through yaml-cpp on every tick: load existing → modify
+ * → dump. Fails the tick if the file doesn't exist.
+ */
+class AppendYamlListItem final : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  AppendYamlListItem(const std::string& name, const BT::NodeConfiguration& config,
+                     const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/path_expansion.hpp
+++ b/include/experimental_behaviors/path_expansion.hpp
@@ -1,0 +1,80 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <wordexp.h>
+
+#include <string>
+#include <string_view>
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+
+namespace experimental_behaviors
+{
+
+/**
+ * @brief Resolves a path string to an absolute filesystem path.
+ *
+ * Accepts three forms:
+ *
+ *   1. **Plain absolute path** — e.g. `/mnt/nvme/autowash/foo.yaml`.
+ *      Returned unchanged.
+ *   2. **Absolute path with shell-style expansion** — `${VAR}` and
+ *      leading `~` are expanded against the calling process's
+ *      environment (via `wordexp(3)` with `WRDE_NOCMD` so command
+ *      substitution is disabled).
+ *   3. **ROS package URL** — `package://<package_name>/<rest>` resolves
+ *      `<package_name>` via
+ *      `ament_index_cpp::get_package_share_directory` and prepends the
+ *      result to `<rest>` (mirrors the convention used by URDF
+ *      `<mesh filename="package://...">`).
+ *
+ * Returns the resolved absolute path. On any expansion failure (unknown
+ * package, malformed env var, etc.) falls back to returning the literal
+ * input; downstream `std::filesystem::exists` / `YAML::LoadFile` calls
+ * surface the resulting failure to the caller with a useful error.
+ */
+inline std::string expandPath(const std::string& in)
+{
+  // Form 3: package://<pkg>/<rest>
+  static constexpr std::string_view kPackagePrefix = "package://";
+  if (in.compare(0, kPackagePrefix.size(), kPackagePrefix) == 0)
+  {
+    const std::string rest = in.substr(kPackagePrefix.size());
+    const auto slash = rest.find('/');
+    const std::string pkg = (slash == std::string::npos) ? rest : rest.substr(0, slash);
+    const std::string sub = (slash == std::string::npos) ? "" : rest.substr(slash);
+    try
+    {
+      const std::string share = ament_index_cpp::get_package_share_directory(pkg);
+      return share + sub;
+    }
+    catch (const std::exception&)
+    {
+      return in;  // literal fallback — caller surfaces the failure at file-open time
+    }
+  }
+
+  // Forms 1 & 2: wordexp handles plain absolute paths and ${VAR} / `~` expansion.
+  wordexp_t exp;
+  std::string out;
+  if (wordexp(in.c_str(), &exp, WRDE_NOCMD) == 0)
+  {
+    if (exp.we_wordc > 0 && exp.we_wordv[0] != nullptr)
+    {
+      out = exp.we_wordv[0];
+    }
+    wordfree(&exp);
+  }
+  if (out.empty())
+  {
+    out = in;
+  }
+  return out;
+}
+
+}  // namespace experimental_behaviors

--- a/include/experimental_behaviors/write_yaml_value.hpp
+++ b/include/experimental_behaviors/write_yaml_value.hpp
@@ -1,0 +1,51 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace experimental_behaviors
+{
+/**
+ * @brief Sets a value at a nested key path in a YAML file. Mirror of
+ * `ReadYamlValue`, with an absolute `file_path` instead of
+ * `package_name` + `relative_file_path` (because writes target
+ * runtime-generated locations rather than installed package shares).
+ *
+ * | Data Port Name | Port Type | Object Type  |
+ * | -------------- | --------- | ------------ |
+ * | file_path      | input     | std::string  |
+ * | key1           | input     | std::string  |
+ * | key2..key5     | input     | std::string  |
+ * | value          | input     | std::string  |
+ *
+ * `key1` is mandatory; `key2`–`key5` are optional and skipped when
+ * empty (matching `ReadYamlValue`). `value` is parsed as YAML before
+ * being stored, so scalars (`"B"`), inline maps
+ * (`"{ option: A, success: false }"`), and sequences (`"[a, b, c]"`)
+ * all flow through the same string port.
+ *
+ * Round-trips through yaml-cpp on every tick: load existing → modify
+ * → dump. Each call is atomic, so partial files survive crashes
+ * mid-operation. Fails the tick if the file doesn't exist (this
+ * behavior does not create files; pair with whatever step is
+ * responsible for initialization).
+ */
+class WriteYamlValue final : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  WriteYamlValue(const std::string& name, const BT::NodeConfiguration& config,
+                 const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+  BT::NodeStatus tick() override;
+};
+}  // namespace experimental_behaviors

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>moveit_studio_common</build_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>control_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>moveit_pro_base</depend>
@@ -21,6 +22,7 @@
   <depend>behaviortree_cpp</depend>
   <depend>tl_expected</depend>
   <depend>trajectory_msgs</depend>
+  <depend>yaml-cpp</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/src/append_yaml_list_item.cpp
+++ b/src/append_yaml_list_item.cpp
@@ -1,0 +1,191 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/append_yaml_list_item.hpp>
+
+#include <yaml-cpp/yaml.h>
+#include <experimental_behaviors/path_expansion.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace
+{
+inline constexpr auto kDescriptionAppendYamlListItem = R"(
+                <p>
+                    Appends a value to a sequence at a nested key path in a YAML file. Companion to
+                    <code>WriteYamlValue</code> (set) and <code>ReadYamlList</code> (read).
+                    Takes the file location as a single <code>file_path</code> port that accepts
+                    an absolute path, an absolute path with <code>${VAR}</code> / leading
+                    <code>~</code> expansion, or a ROS <code>package://&lt;pkg&gt;/&lt;rest&gt;</code> URL.
+                </p>
+                <p>
+                    The keyed location must either be absent (a new sequence is created) or already
+                    be a sequence; appending into a scalar or map fails the tick. The
+                    <code>value</code> port is parsed as YAML before being appended, so scalars
+                    and inline maps (<code>"{ key: val, ... }"</code>) both work through the same
+                    string port.
+                </p>
+                <p>
+                    Round-trips through yaml-cpp on every tick: load existing &rarr; modify &rarr; dump.
+                    Fails the tick if the file does not exist.
+                </p>
+            )";
+
+constexpr auto kPortIDFilePath = "file_path";
+constexpr auto kPortIDKey1 = "key1";
+constexpr auto kPortIDKey2 = "key2";
+constexpr auto kPortIDKey3 = "key3";
+constexpr auto kPortIDKey4 = "key4";
+constexpr auto kPortIDKey5 = "key5";
+constexpr auto kPortIDValue = "value";
+}  // namespace
+
+namespace experimental_behaviors
+{
+AppendYamlListItem::AppendYamlListItem(const std::string& name, const BT::NodeConfiguration& config,
+                                       const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList AppendYamlListItem::providedPorts()
+{
+  return { BT::InputPort<std::string>(kPortIDFilePath,
+                                      "Path to the YAML file. Accepts an absolute path "
+                                      "(/home/user/foo.yaml), an absolute path with shell-style ${VAR} / "
+                                      "leading ~ expansion (${HOME}/foo.yaml), or a ROS package URL "
+                                      "(package://my_pkg/config/foo.yaml resolves via "
+                                      "ament_index_cpp::get_package_share_directory)."),
+           BT::InputPort<std::string>(kPortIDKey1, "First key to traverse YAML structure (mandatory)"),
+           BT::InputPort<std::string>(kPortIDKey2, "", "Second key (optional)"),
+           BT::InputPort<std::string>(kPortIDKey3, "", "Third key (optional)"),
+           BT::InputPort<std::string>(kPortIDKey4, "", "Fourth key (optional)"),
+           BT::InputPort<std::string>(kPortIDKey5, "", "Fifth key (optional)"),
+           BT::InputPort<std::string>(kPortIDValue, "Value to append. Parsed as YAML, so scalars and inline maps "
+                                                    "(`{ key: val, ... }`) both work through the same string port.") };
+}
+
+BT::KeyValueVector AppendYamlListItem::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "YAML Operations" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey, kDescriptionAppendYamlListItem } };
+}
+
+BT::NodeStatus AppendYamlListItem::tick()
+{
+  const auto& logger = shared_resources_->node->get_logger();
+
+  const auto file_path_in = getInput<std::string>(kPortIDFilePath);
+  const auto key1_in = getInput<std::string>(kPortIDKey1);
+  const auto value_in = getInput<std::string>(kPortIDValue);
+
+  if (!file_path_in || file_path_in->empty())
+  {
+    RCLCPP_ERROR(logger, "AppendYamlListItem: 'file_path' is required.");
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!key1_in || key1_in->empty())
+  {
+    RCLCPP_ERROR(logger, "AppendYamlListItem: 'key1' is required.");
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!value_in)
+  {
+    RCLCPP_ERROR(logger, "AppendYamlListItem: 'value' is required (empty string allowed).");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const std::string file_path = expandPath(file_path_in.value());
+
+  std::vector<std::string> keys;
+  keys.push_back(key1_in.value());
+  for (const char* port_id : { kPortIDKey2, kPortIDKey3, kPortIDKey4, kPortIDKey5 })
+  {
+    auto v = getInput<std::string>(port_id);
+    if (v && !v->empty())
+    {
+      keys.push_back(v.value());
+    }
+  }
+
+  if (!std::filesystem::exists(file_path))
+  {
+    RCLCPP_ERROR(logger, "AppendYamlListItem: file does not exist: %s", file_path.c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  YAML::Node root;
+  try
+  {
+    root = YAML::LoadFile(file_path);
+  }
+  catch (const YAML::Exception& e)
+  {
+    RCLCPP_ERROR(logger, "AppendYamlListItem: failed to parse '%s': %s", file_path.c_str(), e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  YAML::Node parsed_value;
+  try
+  {
+    parsed_value = YAML::Load(value_in.value());
+  }
+  catch (const YAML::Exception& e)
+  {
+    RCLCPP_ERROR(logger, "AppendYamlListItem: failed to parse 'value' as YAML: %s", e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Traverse to the parent of the leaf key, creating intermediate maps as needed.
+  YAML::Node node = root;
+  for (size_t i = 0; i + 1 < keys.size(); ++i)
+  {
+    const auto& k = keys[i];
+    if (!node[k] || node[k].IsNull())
+    {
+      node[k] = YAML::Node(YAML::NodeType::Map);
+    }
+    node = node[k];
+  }
+
+  // Ensure the leaf is a sequence (creating it if absent).
+  const auto& leaf = keys.back();
+  if (!node[leaf] || node[leaf].IsNull())
+  {
+    node[leaf] = YAML::Node(YAML::NodeType::Sequence);
+  }
+  if (!node[leaf].IsSequence())
+  {
+    RCLCPP_ERROR(logger, "AppendYamlListItem: target at the keyed location exists and is not a sequence.");
+    return BT::NodeStatus::FAILURE;
+  }
+  node[leaf].push_back(parsed_value);
+
+  try
+  {
+    std::ofstream out(file_path);
+    if (!out)
+    {
+      RCLCPP_ERROR(logger, "AppendYamlListItem: failed to open '%s' for writing.", file_path.c_str());
+      return BT::NodeStatus::FAILURE;
+    }
+    out << root;
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(logger, "AppendYamlListItem: failed to write '%s': %s", file_path.c_str(), e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace experimental_behaviors

--- a/src/append_yaml_list_item.cpp
+++ b/src/append_yaml_list_item.cpp
@@ -145,30 +145,75 @@ BT::NodeStatus AppendYamlListItem::tick()
     return BT::NodeStatus::FAILURE;
   }
 
-  // Traverse to the parent of the leaf key, creating intermediate maps as needed.
-  YAML::Node node = root;
-  for (size_t i = 0; i + 1 < keys.size(); ++i)
-  {
-    const auto& k = keys[i];
-    if (!node[k] || node[k].IsNull())
+  // yaml-cpp gotcha: `YAML::Node node = root; node = node[k]; ... ` does NOT
+  // propagate writes back to root — the intermediate `node = node[k]` rebinds
+  // to a detached node. Use chained subscript instead (yaml-cpp evaluates the
+  // whole path correctly when it's a single expression).
+  //
+  // Strategy: read the existing leaf value via chained subscript (auto-creating
+  // intermediates as Maps if absent), validate it's a Sequence (or absent),
+  // build a new Sequence with the appended item, and re-assign at the same
+  // chained path. The explicit re-assignment guarantees propagation.
+  auto get_leaf = [&]() -> YAML::Node {
+    switch (keys.size())
     {
-      node[k] = YAML::Node(YAML::NodeType::Map);
+      case 1:
+        return root[keys[0]];
+      case 2:
+        return root[keys[0]][keys[1]];
+      case 3:
+        return root[keys[0]][keys[1]][keys[2]];
+      case 4:
+        return root[keys[0]][keys[1]][keys[2]][keys[3]];
+      case 5:
+        return root[keys[0]][keys[1]][keys[2]][keys[3]][keys[4]];
+      default:
+        return YAML::Node();
     }
-    node = node[k];
+  };
+  if (keys.size() > 5)
+  {
+    RCLCPP_ERROR(logger, "AppendYamlListItem: unsupported key depth %zu (max 5).", keys.size());
+    return BT::NodeStatus::FAILURE;
   }
 
-  // Ensure the leaf is a sequence (creating it if absent).
-  const auto& leaf = keys.back();
-  if (!node[leaf] || node[leaf].IsNull())
-  {
-    node[leaf] = YAML::Node(YAML::NodeType::Sequence);
-  }
-  if (!node[leaf].IsSequence())
+  YAML::Node existing = get_leaf();
+  if (existing.IsDefined() && !existing.IsNull() && !existing.IsSequence())
   {
     RCLCPP_ERROR(logger, "AppendYamlListItem: target at the keyed location exists and is not a sequence.");
     return BT::NodeStatus::FAILURE;
   }
-  node[leaf].push_back(parsed_value);
+
+  // Build a fresh sequence with the existing items (if any) plus the new one.
+  YAML::Node new_seq(YAML::NodeType::Sequence);
+  if (existing.IsSequence())
+  {
+    for (const auto& item : existing)
+    {
+      new_seq.push_back(item);
+    }
+  }
+  new_seq.push_back(parsed_value);
+
+  // Re-assign at the chained path so the write propagates to root.
+  switch (keys.size())
+  {
+    case 1:
+      root[keys[0]] = new_seq;
+      break;
+    case 2:
+      root[keys[0]][keys[1]] = new_seq;
+      break;
+    case 3:
+      root[keys[0]][keys[1]][keys[2]] = new_seq;
+      break;
+    case 4:
+      root[keys[0]][keys[1]][keys[2]][keys[3]] = new_seq;
+      break;
+    case 5:
+      root[keys[0]][keys[1]][keys[2]][keys[3]][keys[4]] = new_seq;
+      break;
+  }
 
   try
   {

--- a/src/register_behaviors.cpp
+++ b/src/register_behaviors.cpp
@@ -9,6 +9,7 @@
 #include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
 
 #include "experimental_behaviors/access_interface_value_from_group.hpp"
+#include "experimental_behaviors/append_yaml_list_item.hpp"
 #include "experimental_behaviors/create_dynamic_interface_group_values.hpp"
 #include "experimental_behaviors/create_interface_value.hpp"
 #include "experimental_behaviors/get_blackboard_by_key.hpp"
@@ -18,6 +19,7 @@
 #include "experimental_behaviors/publish_dynamic_interface_group_values.hpp"
 #include "experimental_behaviors/set_blackboard_by_key.hpp"
 #include "experimental_behaviors/trajectory_to_path.hpp"
+#include "experimental_behaviors/write_yaml_value.hpp"
 
 #include <pluginlib/class_list_macros.hpp>
 
@@ -46,6 +48,8 @@ public:
     moveit_pro::behaviors::registerBehavior<GetBlackboardByKey>(factory, "GetBlackboardByKey", shared_resources);
     moveit_pro::behaviors::registerBehavior<SetBlackboardByKey>(factory, "SetBlackboardByKey", shared_resources);
     moveit_pro::behaviors::registerBehavior<TrajectoryToPath>(factory, "TrajectoryToPath", shared_resources);
+    moveit_pro::behaviors::registerBehavior<WriteYamlValue>(factory, "WriteYamlValue", shared_resources);
+    moveit_pro::behaviors::registerBehavior<AppendYamlListItem>(factory, "AppendYamlListItem", shared_resources);
   }
 };
 }  // namespace experimental_behaviors

--- a/src/write_yaml_value.cpp
+++ b/src/write_yaml_value.cpp
@@ -1,0 +1,185 @@
+// Copyright 2026 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <experimental_behaviors/write_yaml_value.hpp>
+
+#include <yaml-cpp/yaml.h>
+#include <experimental_behaviors/path_expansion.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace
+{
+inline constexpr auto kDescriptionWriteYamlValue = R"(
+                <p>
+                    Sets a value at a nested key path in a YAML file. Companion to
+                    <code>ReadYamlValue</code>; takes the file location as a single
+                    <code>file_path</code> port that accepts an absolute path, an absolute path
+                    with <code>${VAR}</code> / leading <code>~</code> expansion, or a ROS
+                    <code>package://&lt;pkg&gt;/&lt;rest&gt;</code> URL.
+                </p>
+                <p>
+                    The <code>value</code> port is parsed as YAML before being stored, so scalars
+                    (<code>"B"</code>), inline maps (<code>"{ option: A, success: false }"</code>),
+                    and sequences (<code>"[a, b, c]"</code>) all flow through the same string port.
+                    Intermediate maps along <code>key1..key5</code> are created if missing; an
+                    existing value at the leaf is overwritten.
+                </p>
+                <p>
+                    Round-trips through yaml-cpp on every tick: load existing &rarr; modify &rarr; dump.
+                    Fails the tick if the file does not exist.
+                </p>
+            )";
+
+constexpr auto kPortIDFilePath = "file_path";
+constexpr auto kPortIDKey1 = "key1";
+constexpr auto kPortIDKey2 = "key2";
+constexpr auto kPortIDKey3 = "key3";
+constexpr auto kPortIDKey4 = "key4";
+constexpr auto kPortIDKey5 = "key5";
+constexpr auto kPortIDValue = "value";
+}  // namespace
+
+namespace experimental_behaviors
+{
+WriteYamlValue::WriteYamlValue(const std::string& name, const BT::NodeConfiguration& config,
+                               const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList WriteYamlValue::providedPorts()
+{
+  return {
+    BT::InputPort<std::string>(kPortIDFilePath, "Path to the YAML file. Accepts an absolute path "
+                                                "(/home/user/foo.yaml), an absolute path with shell-style ${VAR} / "
+                                                "leading ~ expansion (${HOME}/foo.yaml), or a ROS package URL "
+                                                "(package://my_pkg/config/foo.yaml resolves via "
+                                                "ament_index_cpp::get_package_share_directory)."),
+    BT::InputPort<std::string>(kPortIDKey1, "First key to traverse YAML structure (mandatory)"),
+    BT::InputPort<std::string>(kPortIDKey2, "", "Second key (optional)"),
+    BT::InputPort<std::string>(kPortIDKey3, "", "Third key (optional)"),
+    BT::InputPort<std::string>(kPortIDKey4, "", "Fourth key (optional)"),
+    BT::InputPort<std::string>(kPortIDKey5, "", "Fifth key (optional)"),
+    BT::InputPort<std::string>(kPortIDValue, "Value to write at the keyed location. Parsed as YAML, so scalars, "
+                                             "inline maps (`{ key: val, ... }`), and sequences (`[a, b, c]`) all "
+                                             "work through the same string port.")
+  };
+}
+
+BT::KeyValueVector WriteYamlValue::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "YAML Operations" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey, kDescriptionWriteYamlValue } };
+}
+
+BT::NodeStatus WriteYamlValue::tick()
+{
+  const auto& logger = shared_resources_->node->get_logger();
+
+  const auto file_path_in = getInput<std::string>(kPortIDFilePath);
+  const auto key1_in = getInput<std::string>(kPortIDKey1);
+  const auto value_in = getInput<std::string>(kPortIDValue);
+
+  if (!file_path_in || file_path_in->empty())
+  {
+    RCLCPP_ERROR(logger, "WriteYamlValue: 'file_path' is required.");
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!key1_in || key1_in->empty())
+  {
+    RCLCPP_ERROR(logger, "WriteYamlValue: 'key1' is required.");
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!value_in)
+  {
+    RCLCPP_ERROR(logger, "WriteYamlValue: 'value' is required (empty string allowed).");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const std::string file_path = expandPath(file_path_in.value());
+
+  // Build keys vector — mirrors ReadYamlValue's logic (skip empty optional
+  // keys, keep order).
+  std::vector<std::string> keys;
+  keys.push_back(key1_in.value());
+  for (const char* port_id : { kPortIDKey2, kPortIDKey3, kPortIDKey4, kPortIDKey5 })
+  {
+    auto v = getInput<std::string>(port_id);
+    if (v && !v->empty())
+    {
+      keys.push_back(v.value());
+    }
+  }
+
+  if (!std::filesystem::exists(file_path))
+  {
+    RCLCPP_ERROR(logger, "WriteYamlValue: file does not exist: %s", file_path.c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  YAML::Node root;
+  try
+  {
+    root = YAML::LoadFile(file_path);
+  }
+  catch (const YAML::Exception& e)
+  {
+    RCLCPP_ERROR(logger, "WriteYamlValue: failed to parse '%s': %s", file_path.c_str(), e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  YAML::Node parsed_value;
+  try
+  {
+    parsed_value = YAML::Load(value_in.value());
+  }
+  catch (const YAML::Exception& e)
+  {
+    RCLCPP_ERROR(logger, "WriteYamlValue: failed to parse 'value' as YAML: %s", e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Traverse to the parent of the leaf key, creating empty maps along the way
+  // for any missing intermediate nodes.
+  YAML::Node node = root;
+  for (size_t i = 0; i + 1 < keys.size(); ++i)
+  {
+    const auto& k = keys[i];
+    if (!node[k] || node[k].IsNull())
+    {
+      node[k] = YAML::Node(YAML::NodeType::Map);
+    }
+    node = node[k];
+  }
+
+  node[keys.back()] = parsed_value;
+
+  try
+  {
+    std::ofstream out(file_path);
+    if (!out)
+    {
+      RCLCPP_ERROR(logger, "WriteYamlValue: failed to open '%s' for writing.", file_path.c_str());
+      return BT::NodeStatus::FAILURE;
+    }
+    out << root;
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(logger, "WriteYamlValue: failed to write '%s': %s", file_path.c_str(), e.what());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  return BT::NodeStatus::SUCCESS;
+}
+}  // namespace experimental_behaviors

--- a/src/write_yaml_value.cpp
+++ b/src/write_yaml_value.cpp
@@ -149,20 +149,31 @@ BT::NodeStatus WriteYamlValue::tick()
     return BT::NodeStatus::FAILURE;
   }
 
-  // Traverse to the parent of the leaf key, creating empty maps along the way
-  // for any missing intermediate nodes.
-  YAML::Node node = root;
-  for (size_t i = 0; i + 1 < keys.size(); ++i)
+  // yaml-cpp gotcha: `YAML::Node node = root; node = node[k]; node[k2] = v` does
+  // NOT propagate the write to root — the intermediate `node = node[k]` rebinds
+  // to a detached node. Use chained subscript instead, which yaml-cpp handles
+  // correctly because the whole path is evaluated as a single expression.
+  switch (keys.size())
   {
-    const auto& k = keys[i];
-    if (!node[k] || node[k].IsNull())
-    {
-      node[k] = YAML::Node(YAML::NodeType::Map);
-    }
-    node = node[k];
+    case 1:
+      root[keys[0]] = parsed_value;
+      break;
+    case 2:
+      root[keys[0]][keys[1]] = parsed_value;
+      break;
+    case 3:
+      root[keys[0]][keys[1]][keys[2]] = parsed_value;
+      break;
+    case 4:
+      root[keys[0]][keys[1]][keys[2]][keys[3]] = parsed_value;
+      break;
+    case 5:
+      root[keys[0]][keys[1]][keys[2]][keys[3]][keys[4]] = parsed_value;
+      break;
+    default:
+      RCLCPP_ERROR(logger, "WriteYamlValue: unsupported key depth %zu (max 5).", keys.size());
+      return BT::NodeStatus::FAILURE;
   }
-
-  node[keys.back()] = parsed_value;
 
   try
   {


### PR DESCRIPTION
## WriteYamlValue
- WriteYamlValue sets a value at a nested key path in a YAML file. The file_path port accepts
  - an absolute path, or
  - an absolute path with ${VAR} and leading ~ expansion, or
  - a ROS package URL (package://<pkg>/<rest>) resolved via ament_index_cpp::get_package_share_directory. 
- The value port is parsed as YAML before storing, so scalars, inline maps, and sequences all flow through a single string port. Intermediate maps along key1..key5 are auto-created.

## AppendYamlListItem
- AppendYamlListItem appends a YAML-parsed value to a sequence at the same kind of key path. Creates the sequence if absent; fails the tick if the keyed location exists and is not a sequence.
- Path resolution shared via a small inline expandPath helper at include/experimental_behaviors/path_expansion.hpp.

---

- Both behaviors round-trip through yaml-cpp on every tick (load existing -> modify -> dump). Each call is atomic, so partial files survive crashes mid-operation. Fails the tick if the file does not exist; these behaviors do not create files.
- Adds yaml-cpp and ament_index_cpp as package dependencies.